### PR TITLE
Update Dependabot configuration to remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
       day: 'monday'
       time: '09:00'
     open-pull-requests-limit: 5
-    reviewers:
-      - 'mona-actions'
-    assignees:
-      - 'mona-actions'
     commit-message:
       prefix: 'deps'
       include: 'scope'
@@ -24,10 +20,6 @@ updates:
       day: 'monday'
       time: '09:00'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'mona-actions'
-    assignees:
-      - 'mona-actions'
     commit-message:
       prefix: 'ci'
       include: 'scope'


### PR DESCRIPTION
This pull request modifies the `.github/dependabot.yml` configuration to streamline dependency update workflows by removing reviewers and assignees for Dependabot pull requests.

### Simplifications in Dependabot configuration:

* Removed the `reviewers` and `assignees` fields from the configuration for dependencies with the prefix `deps`. (`[.github/dependabot.ymlL11-L14](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-L14)`)
* Removed the `reviewers` and `assignees` fields from the configuration for dependencies with the prefix `ci`. (`[.github/dependabot.ymlL27-L30](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L27-L30)`)